### PR TITLE
Add camelCase parsing for prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,12 @@ const flatten = require('./flatten')
 function habitat(prefix, defaults) {
   if (!(this instanceof habitat))
     return new habitat(prefix, defaults);
-  if (prefix)
+  if (prefix) {
+    if (prefix.match(/[a-z]+[A-Z]/)) {
+      prefix = fromCamelCase(prefix);
+    }
     this.prefix = prefix.toUpperCase();
+  }
   if (defaults)
     this.defaults = this.setDefaults(defaults);
 };

--- a/test/habitat.test.js
+++ b/test/habitat.test.js
@@ -12,7 +12,7 @@ test('habitat#get: basic test', function (t) {
   t.same(env.get('hello'), 'world');
 
   var env2 = new habitat('HABITAT');
-  t.same(env.get('HELLO'), 'world');
+  t.same(env2.get('HELLO'), 'world');
   t.end();
 });
 

--- a/test/habitat.test.js
+++ b/test/habitat.test.js
@@ -16,6 +16,14 @@ test('habitat#get: basic test', function (t) {
   t.end();
 });
 
+test('habitat#get: camelcase prefix', function(t) {
+  process.env['HABITAT_FOO_HELLO'] = 'world';
+
+  var env = new habitat('habitatFoo');
+  t.same(env.get('hello'), 'world');
+  t.end();
+});
+
 test('habitat#get: no prefix', function (t) {
   process.env['SOMETHING'] = 'that thing';
   var env = new habitat();


### PR DESCRIPTION
Only realized this feature was missing when I tried to use it.

It encourages using a more specific prefix, which helps preventing namespace collisions.
