### PR TITLE
Fix a problem with camelCase key and default value and with partially overwritten defaults

### DIFF
--- a/flatten.js
+++ b/flatten.js
@@ -1,13 +1,13 @@
 const fromCamelCase = require('./from-camel-case')
 const reduce = require('lodash.reduce')
 const xtend = require('xtend')
+const prefixKey = require('./prefix-key')
 
 module.exports = function flatten(obj, prefix) {
   prefix = prefix || ''
 
   function makeKey(s) {
-    if (!prefix) return s
-    return prefix + '_' + s
+    return prefixKey(prefix, s)
   }
 
   return reduce(obj, function (result, val, key) {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const xtend = require('xtend')
 const pathutil = require('path');
 const fromCamelCase = require('./from-camel-case')
 const flatten = require('./flatten')
+const prefixKey = require('./prefix-key');
 
 function habitat(prefix, defaults) {
   if (!(this instanceof habitat))
@@ -99,7 +100,7 @@ habitat.prototype.set = function set(key, value) {
   if (typeof value !== 'string' && typeof value !== 'number') {
     if (typeof value === 'object') {
       eachKey(value, function(childKey) {
-        this.set(key + '_' + childKey, value[childKey]);
+        this.set(prefixKey(key, childKey), value[childKey]);
       }.bind(this));
     }
     value = JSON.stringify(value);

--- a/index.js
+++ b/index.js
@@ -22,10 +22,19 @@ function habitat(prefix, defaults) {
  * Setup default environment options
  */
 
-habitat.prototype.setDefaults = function setDefaults(defaults) {
+habitat.prototype.setDefaults = function setDefaults(defaults, prefix) {
   eachKey(defaults, function (key) {
-    if (typeof this.get(key) === 'undefined')
-      this.set(key, defaults[key])
+    var prefixedKey = prefixKey(prefix, key);
+    switch (typeof this.get(prefixedKey)) {
+      default:
+        break;
+      case 'undefined':
+        this.set(prefixedKey, defaults[key]);
+        break;
+      case 'object':
+        this.setDefaults(defaults[key], prefixedKey);
+        break;
+    }
   }.bind(this));
   return this;
 };

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ habitat.prototype.setDefaults = function setDefaults(defaults) {
 habitat.prototype.get = function get(key, someDefault) {
   var value, envkey;
   if (key.match(/[a-z]+[A-Z]/))
-    return this.get(fromCamelCase(key));
+    return this.get(fromCamelCase(key), someDefault);
 
   envkey = this.envkey(key);
   value = process.env[envkey];

--- a/prefix-key.js
+++ b/prefix-key.js
@@ -1,0 +1,3 @@
+module.exports = function(prefix, key) {
+  return prefix ? prefix + '_' + key : key;
+};

--- a/test/habitat.test.js
+++ b/test/habitat.test.js
@@ -149,6 +149,7 @@ test('habitat#get: array parsing', function (t) {
 test('habitat#get: defaults', function (t) {
   var env = new habitat('noexist');
   t.same(env.get('port', 3000), 3000);
+  t.same(env.get('redisPort', 6379), 6379);
   t.same(env.get('yayay'), undefined);
   t.end();
 });

--- a/test/habitat.test.js
+++ b/test/habitat.test.js
@@ -116,6 +116,20 @@ test('habitat constructor: second-level defaults', function(t) {
   t.end();
 });
 
+test('habitat constructor: partially overwritten second-level defaults', function(t) {
+  process.env['HABITAT_PARENT_SECOND'] = 'overwritten';
+  var env = habitat('habitat', {
+    parent: {
+      first: 'foo',
+      second: 'bar'
+    }
+  });
+  t.same(env.get('parentFirst'), 'foo');
+  t.same(env.get('parentSecond'), 'overwritten');
+  t.end();
+  delete process.env['HABITAT_PARENT_SECOND']
+});
+
 test('habitat#unset', function (t) {
   process.env['HABITAT_WUT'] = 'lol';
   var env = new habitat('habitat');

--- a/test/prefix-key.test.js
+++ b/test/prefix-key.test.js
@@ -1,0 +1,22 @@
+var prefixKey = require('../prefix-key');
+var test = require('tap').test;
+
+test('prefix-key: with null prefix', function(t) {
+  t.same(prefixKey(null, 'key'), 'key', 'should return key');
+  t.end();
+});
+
+test('prefix-key: with undefined prefix', function(t) {
+  t.same(prefixKey(undefined, 'key'), 'key', 'should return non-prefixed key');
+  t.end();
+});
+
+test('prefix-key: with null prefix', function(t) {
+  t.same(prefixKey('', 'key'), 'key', 'should return non-prefixed key');
+  t.end();
+});
+
+test('prefix-key: with prefix', function(t) {
+  t.same(prefixKey('prefix', 'key'), 'prefix_key', 'should return prefixed key');
+  t.end();
+});


### PR DESCRIPTION
The default value to `get()` was never passed on after parsing the key from camelCase.

The latest commit fixes an issue with my fix to issue #15. I'm not completely happy with having almost the same recursive logic in two places (`set()` and `setDefaults()`), but couldn't figure out a better way of doing it.

In the process of fixing the latter issue I stumbled on some duplicated logic which I extracted into a module of its own.
